### PR TITLE
Allows a decimal number of seconds as delay between processes

### DIFF
--- a/SystemDaemon.php
+++ b/SystemDaemon.php
@@ -429,7 +429,7 @@ abstract class SystemDaemon
 
 	if( ! $this->killed ) {
 	  $this->log->debug("sleeping %d seconds", $this->delay);
-	  sleep($this->delay);
+	  usleep(1000000 * $this->delay);
 	}
       }
     $this->stop();


### PR DESCRIPTION
PHP's [sleep()](https://php.net/sleep) function accepts only integer arguments.

If anyone would like a delay shorter than one second, it will silently cast this delay to an int, resulting in a sleep of zero seconds.

Using PHP's [usleep()](http://php.net/usleep) function, we are able to adjust the delay to the microsecond.